### PR TITLE
fix: switch user/assistant avatar positions

### DIFF
--- a/pages/components/MessageItem/index.module.scss
+++ b/pages/components/MessageItem/index.module.scss
@@ -18,10 +18,10 @@
         }
     }
     .user {
-        margin-right: 20px;
+        margin-left: 20px;
     }
     .assistant {
-        margin-left: 20px;
+        margin-right: 20px;
     }
     .content {
         flex: 1;

--- a/pages/components/MessageItem/index.tsx
+++ b/pages/components/MessageItem/index.tsx
@@ -102,6 +102,13 @@ const MessageItem: React.FC<{
         >
             {role === ERole.user ? (
                 <>
+                    <div className={styles.placeholder}></div>
+                    <div
+                        className={styles.content}
+                        dangerouslySetInnerHTML={{
+                            __html: htmlString(),
+                        }}
+                    ></div>
                     <div className={`${styles.user} ${styles.avatar}`}>
                         {avatar && (
                             <Image
@@ -113,23 +120,9 @@ const MessageItem: React.FC<{
                             />
                         )}
                     </div>
-                    <div
-                        className={styles.content}
-                        dangerouslySetInnerHTML={{
-                            __html: htmlString(),
-                        }}
-                    ></div>
-                    <div className={styles.placeholder}></div>
                 </>
             ) : (
                 <>
-                    <div className={styles.placeholder}></div>
-                    <div
-                        className={styles.content}
-                        dangerouslySetInnerHTML={{
-                            __html: htmlString(),
-                        }}
-                    ></div>
                     <div className={`${styles.assistant} ${styles.avatar}`}>
                         {avatar && (
                             <Image
@@ -141,6 +134,13 @@ const MessageItem: React.FC<{
                             />
                         )}
                     </div>
+                    <div
+                        className={styles.content}
+                        dangerouslySetInnerHTML={{
+                            __html: htmlString(),
+                        }}
+                    ></div>
+                    <div className={styles.placeholder}></div>
                 </>
             )}
             {showRetry && onRetry && (


### PR DESCRIPTION
User's avatar should be placed on the right, and bot's on the left.

<img width="975" alt="image" src="https://user-images.githubusercontent.com/8225666/224594176-afeeca2d-1595-4fbf-b789-064d6730772c.png">
